### PR TITLE
Fix successful login check. Enhance get_pod_url method with path parameter

### DIFF
--- a/lib/class-diaspora-api.php
+++ b/lib/class-diaspora-api.php
@@ -119,10 +119,15 @@ class Diaspora_API {
   /**
    * The full pod url, with the used protocol.
    *
-   * @var string
+   * @var string $path Path to add to the pod url.
    */
-  public function get_pod_url() {
-    return sprintf( 'http%s://%s', ( $this->_is_secure ) ? 's' : '', $this->_pod );
+  public function get_pod_url( $path = '' ) {
+    // Add a slash to the beginning?
+    if ( 0 !== strpos( $url, '/' ) ) {
+      $path = '/' . $path;
+    }
+
+    return sprintf( 'http%s://%s%s', ( $this->_is_secure ) ? 's' : '', $this->_pod, $path );
   }
 
   /**
@@ -242,7 +247,8 @@ class Diaspora_API {
 
     // Try to sign in.
     $req = $this->_http_request( '/users/sign_in', $params );
-    if ( 200 !== $req->info['http_code'] ) {
+    // If the request failed or we're still on the sign in page, the login failed.
+    if ( 200 !== $req->info['http_code'] || $this->get_pod_url( '/users/sign_in' ) === $req->info['url'] ) {
       // Login failed.
       $this->last_error = __( 'Login failed.', 'wp_to_diaspora' );
       return false;
@@ -363,7 +369,7 @@ class Diaspora_API {
   private function _http_request( $url, $data = array(), $headers = array() ) {
     // Prefix the full pod URL if necessary.
     if ( 0 === strpos( $url, '/' ) ) {
-      $url = $this->get_pod_url() . $url;
+      $url = $this->get_pod_url( $url );
     }
 
     // Define maximum redirects.

--- a/wp-to-diaspora.php
+++ b/wp-to-diaspora.php
@@ -173,7 +173,7 @@ function wp_to_diaspora_post( $post_id, $post ) {
         'created_at' => $post->post_modified,
         'aspects'    => $aspects,
         'nsfw'       => $response->nsfw,
-        'post_url'   => $conn->get_pod_url() . '/posts/' . $response->guid
+        'post_url'   => $conn->get_pod_url( '/posts/' . $response->guid )
       );
       update_post_meta( $post_id, '_wp_to_diaspora_post_history', $diaspora_post_history );
 


### PR DESCRIPTION
When trying to log in, the server always responds with a 200 status code, no matter if the login was successful or not. This has been corrected by checking if we have been redirected to a different page or are still on the login screen.