### PR TITLE
Correct regex for extracting token. Update password encrypt/decrypt.

### DIFF
--- a/lib/class-api.php
+++ b/lib/class-api.php
@@ -116,7 +116,7 @@ class WP2D_API {
    * @var array
    */
   private $_regexes = array(
-    'token'    => '/content="(.*?)" name="csrf-token/',
+    'token'    => '/content="(.*?)" name="csrf-token"|name="csrf-token" content="(.*?)"/',
     'cookie'   => '/Set-Cookie: (.*?);/',
     'aspects'  => '/"aspects"\:(\[.+?\])/',
     'services' => '/"configured_services"\:(\[.+?\])/'

--- a/lib/class-helpers.php
+++ b/lib/class-helpers.php
@@ -88,7 +88,7 @@ class WP2D_Helpers {
    */
   public static function encrypt( $input, $key = AUTH_KEY ) {
     global $wpdb;
-    return base64_encode( $wpdb->get_var( $wpdb->prepare( "SELECT AES_ENCRYPT(%s,%s)", $input, $key ) ) );
+    return $wpdb->get_var( $wpdb->prepare( "SELECT HEX(AES_ENCRYPT(%s,%s))", $input, $key ) );
   }
 
   /**
@@ -100,7 +100,7 @@ class WP2D_Helpers {
    */
   public static function decrypt( $input, $key = AUTH_KEY ) {
     global $wpdb;
-    return $wpdb->get_var( $wpdb->prepare( "SELECT AES_DECRYPT(%s,%s)", base64_decode( $input ), $key ) );
+    return $wpdb->get_var( $wpdb->prepare( "SELECT AES_DECRYPT(UNHEX(%s),%s)", $input, $key ) );
   }
 }
 


### PR DESCRIPTION
Some pods have the properties of the meta tag in a different order, so the regex needs to check both versions.
The password encrypt/decrypt functions now use pure SQL for storing the password, as the AES MySQL functions have padding issues.

See #49 for more info.