### PR TITLE
Wrong constant name

### DIFF
--- a/lib/class-options.php
+++ b/lib/class-options.php
@@ -35,7 +35,7 @@ class WP2D_Options {
     'enabled_post_types' => array( 'post' ),
     'fullentrylink'      => true,
     'display'            => 'full',
-    'version'            => WP_TO_DIASPORA_VERSION
+    'version'            => WP2D_VERSION
   );
 
   /**


### PR DESCRIPTION
The use of the wrong (deprecaded?) constant gives this warning:

> [16-Jun-2015 02:54:06 UTC] PHP Notice:  Use of undefined constant WP_TO_DIASPORA_VERSION - assumed 'WP_TO_DIASPORA_VERSION' in /usr/share/nginx/www/ciubotaru/wp-content/plugins/wp-to-diaspora/lib/class-options.php on line 73