### PR TITLE
Split up class more finely into methods.

### DIFF
--- a/lib/class-contextual-help.php
+++ b/lib/class-contextual-help.php
@@ -165,6 +165,8 @@ class WP2D_Contextual_Help {
 		) );
 
 		// Explain the importance of SSL connections to the pod and the CA certificate bundle.
+		$defined_functions = get_defined_functions();
+		$ssl_can_install = ( ! array_diff( array( 'fopen', 'fwrite', 'fclose', 'file_get_contents', 'file_put_contents' ), $defined_functions['internal'] ) );
 		$screen->add_help_tab( array(
 			'id'      => 'ssl',
 			'title'   => esc_html__( 'SSL', 'wp-to-diaspora' ),
@@ -187,14 +189,13 @@ class WP2D_Contextual_Help {
 						)
 						. '<br><p>' .
 						// See if we can do this automatically.
-						( ( ! array_diff( array( 'fopen', 'fwrite', 'fclose', 'file_get_contents', 'file_put_contents' ), get_defined_functions()['internal'] ) )
+						( ( $ssl_can_install )
 							? sprintf(
 								esc_html_x( 'Your server should allow us to %sdo this%s for you :-)', 'Placeholders are HTML for links.', 'wp-to-diaspora' ),
 								'<a href="' . add_query_arg( 'temp_ssl_fix', '' ) . '" class="button">', '</a>'
 							)
 							: ''
-						)
-						. '</p>
+						) . '</p>
 				</ul>
 				<p class="dashicons-before dashicons-info">' . esc_html__( 'NOTE: If you choose the temporary option, the copy procedure needs to be done every time the plugin is updated because all files get replaced!', 'wp-to-diaspora' ) . '</p>',
 		) );

--- a/lib/class-contextual-help.php
+++ b/lib/class-contextual-help.php
@@ -9,25 +9,10 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-// Define external link constants.
-define( 'WP2D_EXT_WPORG',         'https://wordpress.org/plugins/wp-to-diaspora' );
-define( 'WP2D_EXT_I18N',          'https://poeditor.com/join/project?hash=c085b3654a5e04c69ec942e0f136716a' );
-define( 'WP2D_EXT_GH',            'https://github.com/gutobenn/wp-to-diaspora' );
-define( 'WP2D_EXT_DONATE',        'https://github.com/gutobenn/wp-to-diaspora#donate' );
-define( 'WP2D_EXT_GH_ISSUES',     'https://github.com/gutobenn/wp-to-diaspora/issues' );
-define( 'WP2D_EXT_GH_ISSUES_NEW', 'https://github.com/gutobenn/wp-to-diaspora/issues/new' );
-
 /**
  * Class that handles the contextual help.
  */
 class WP2D_Contextual_Help {
-
-	/**
-	 * Has the contextual help already been set up?
-	 *
-	 * @var boolean
-	 */
-	private static $_is_set_up = false;
 
 	/**
 	 * Only instance of this class.
@@ -43,6 +28,58 @@ class WP2D_Contextual_Help {
 	 */
 	private $_settings_tabs = array();
 
+	/**
+	 * Create / Get the instance of this class.
+	 *
+	 * @return WP2D_Contextual_Help Instance of this class.
+	 */
+	public static function instance() {
+		if ( ! isset( self::$_instance ) ) {
+			self::$_instance = new self();
+			self::$_instance->_constants();
+			self::$_instance->_setup();
+		}
+		return self::$_instance;
+	}
+
+	/**
+	 * Define all the required constants.
+	 *
+	 * @since 1.5.0
+	 */
+	private function _constants() {
+		define( 'WP2D_EXT_WPORG',         esc_url( 'https://wordpress.org/plugins/wp-to-diaspora' ) );
+		define( 'WP2D_EXT_I18N',          esc_url( 'https://poeditor.com/join/project?hash=c085b3654a5e04c69ec942e0f136716a' ) );
+		define( 'WP2D_EXT_GH',            esc_url( 'https://github.com/gutobenn/wp-to-diaspora' ) );
+		define( 'WP2D_EXT_DONATE',        esc_url( 'https://github.com/gutobenn/wp-to-diaspora#donate' ) );
+		define( 'WP2D_EXT_GH_ISSUES',     esc_url( 'https://github.com/gutobenn/wp-to-diaspora/issues' ) );
+		define( 'WP2D_EXT_GH_ISSUES_NEW', esc_url( 'https://github.com/gutobenn/wp-to-diaspora/issues/new' ) );
+	}
+
+	/**
+	 * Set up the contextual help menu.
+	 */
+	private function _setup() {
+		// Do we display the help tabs?
+		$post_type = get_current_screen()->post_type;
+		$enabled_post_types = WP2D_Options::instance()->get_option( 'enabled_post_types' );
+		if ( '' !== $post_type && ! in_array( $post_type, $enabled_post_types ) ) {
+			return;
+		}
+
+		// If we don't have a post type, we're on the main settings page.
+		if ( '' === $post_type ) {
+			// Set the sidebar in the contextual help.
+			$this->_set_sidebar();
+
+			// Add the main settings tabs and their content.
+			$this->_add_settings_help_tabs();
+		} else {
+			// Add the post type specific tabs and their content.
+			$this->_add_post_type_help_tabs();
+		}
+	}
+
 	/** Singleton, keep private. */
 	final private function __clone() { }
 
@@ -50,180 +87,14 @@ class WP2D_Contextual_Help {
 	final private function __wakeup() { }
 
 	/** Singleton, keep private. */
-	final private function __construct() {
-		// @todo Split this up to make it easier to read.
-		$this->_settings_tabs = array(
-			// A short overview of the plugin.
-			'overview' => array(
-				'title'   => esc_html__( 'Overview', 'wp-to-diaspora' ),
-				'content' => '<p><strong>' . esc_html__( 'With WP to diaspora*, sharing your WordPress posts to diaspora* is as easy as ever.', 'wp-to-diaspora' ) . '</strong></p>
-					<ol>
-						<li>' . esc_html__( 'Enter your diaspora* login details on the "Setup" tab.', 'wp-to-diaspora' ) . '
-						<li>' . esc_html__( 'Define the default posting behaviour on the "Defaults" tab.', 'wp-to-diaspora' ) . '
-						<li>' . esc_html__( 'Automatically share your WordPress post on diaspora* when publishing it on your website.', 'wp-to-diaspora' ) . '
-						<li>' . esc_html__( 'Check out your new post on diaspora*.', 'wp-to-diaspora' ) . '
-					</ol>',
-			),
-			// How to set up the connection to diaspora*.
-			'setup' => array(
-				'title'   => esc_html__( 'Setup', 'wp-to-diaspora' ),
-				'content' => '<p><strong>' . esc_html__( 'Enter your diaspora* login details to connect your account.', 'wp-to-diaspora' ) . '</strong></p>
-					<ul>
-						<li><strong>' . esc_html__( 'diaspora* Pod', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'This is the domain name of the pod you are on (e.g. joindiaspora.com)', 'wp-to-diaspora' ) . '<br>
-								<em>' . sprintf( esc_html__( 'Use the "%s" button to prepopulate the input field to help choose your pod.', 'wp-to-diaspora' ), esc_html__( 'Refresh pod list', 'wp-to-diaspora' ) ) . '</em>
-						<li><strong>' . esc_html__( 'Username', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'Your diaspora* username (without the pod domain).', 'wp-to-diaspora' ) . '
-						<li><strong>' . esc_html__( 'Password', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'Your diaspora* password.', 'wp-to-diaspora' ) . '
-					</ul>',
-			),
-			// Explain the default options and what they do.
-			'defaults' => array(
-				'title'   => esc_html__( 'Defaults', 'wp-to-diaspora' ),
-				'content' => '<p><strong>' . esc_html__( 'Define the default posting behaviour.', 'wp-to-diaspora' ) . '</strong></p>
-					<ul>
-						<li><strong>' . esc_html__( 'Post types', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'Choose the post types that are allowed to be shared to diaspora*.', 'wp-to-diaspora' ) . '
-						<li><strong>' . esc_html__( 'Post to diaspora*', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'Automatically share new posts to diaspora* when publishing them.', 'wp-to-diaspora' ) . '
-						<li><strong>' . esc_html__( 'Show "Posted at" link?', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'Add a link back to your original post, at the bottom of the diaspora* post.', 'wp-to-diaspora' ) . '
-						<li><strong>' . esc_html__( 'Display', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'Choose whether you would like to post the whole post or just the excerpt.', 'wp-to-diaspora' ) . '
-						<li><strong>' . esc_html__( 'Tags to post', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'You can add tags to your post to make it easier to find on diaspora*.' ) . '<br>
-								<ul>
-									<li><strong>' . esc_html__( 'Global tags', 'wp-to-diaspora' ) . '</strong>: ' . esc_html__( 'Tags that apply to all posts.', 'wp-to-diaspora' ) . '
-									<li><strong>' . esc_html__( 'Custom tags', 'wp-to-diaspora' ) . '</strong>: ' . esc_html__( 'Tags that apply to individual posts (can be set on each post).', 'wp-to-diaspora' ) . '
-									<li><strong>' . esc_html__( 'Post tags',   'wp-to-diaspora' ) . '</strong>: ' . esc_html__( 'Default WordPress Tags of individual posts.', 'wp-to-diaspora' ) . '
-								</ul>
-						<li><strong>' . esc_html__( 'Global tags', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'A list of tags that gets added to every post.', 'wp-to-diaspora' ) . '
-						<li><strong>' . esc_html__( 'Aspects', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'Decide which of your diaspora* aspects can see your posts.', 'wp-to-diaspora' ) . '<br>
-								<em>' . sprintf( esc_html__( 'Use the "%s" button to load your aspects from diaspora*.', 'wp-to-diaspora' ), esc_html__( 'Refresh Aspects', 'wp-to-diaspora' ) ) . '</em>
-						<li><strong>' . esc_html__( 'Services', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'Choose the services your new diaspora* post gets shared to.', 'wp-to-diaspora' ) . '<br>
-								<em>' . sprintf( esc_html__( 'Use the "%s" button to fetch the list of your connected services from diaspora*.', 'wp-to-diaspora' ), esc_html__( 'Refresh Services', 'wp-to-diaspora' ) ) . '</em>
-					</ul>',
-			),
-			// Explain the importance of SSL connections to the pod and the CA certificate bundle.
-			'ssl' => array(
-				'title'   => esc_html__( 'SSL', 'wp-to-diaspora' ),
-				'content' => '<p><strong>' . esc_html__( 'WP to diaspora* makes sure the connection to your pod is secure!', 'wp-to-diaspora' ) . '</strong></p>
-					<p>' . esc_html__( 'Most diaspora* pods are secured using SSL (Secure Sockets Layer), which makes your connection encrypted. For this connection to work, your server needs to know that those SSL certificates can be trusted.', 'wp-to-diaspora' ) . '</p>
-					<p>' . esc_html__( 'Therefore, if your server does not have an up to date CA certificate bundle, WP to diaspora* may not work for you.', 'wp-to-diaspora' ) . '</p>
-					<p>' . esc_html__( 'Lucky for you though, we have you covered if this is the case for you!', 'wp-to-diaspora' ) . '</p>
-					<ul>
-						<li><strong>' . esc_html__( 'Get in touch with your hosting provider', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'The best option is for you to get in touch with your hosting provider and ask them to update the bundle for you. They should know what you\'re talking about.', 'wp-to-diaspora' ) . '
-						<li><strong>' . esc_html__( 'Install the CA bundle yourself', 'wp-to-diaspora' ) . '</strong>: ' .
-							sprintf(
-								esc_html_x( 'If you maintain your own server, it\'s your job to keep the bundle up to date. You can find a short and simple way on how to do this %shere%s.', 'Placeholders are HTML for a link.', 'wp-to-diaspora' ),
-								'<a href="http://serverfault.com/a/394835" target="_blank">', '</a>'
-							) . '
-						<li><strong>' . esc_html__( 'Quick "temporary" fix', 'wp-to-diaspora' ) . '</strong>: ' .
-							sprintf(
-								esc_html_x( 'As a temporary solution, you can download the up to date %sCA certificate bundle%s (Right-click &#8594; Save As...) and place the cacert.pem file at the top level of the WP to diaspora* plugin folder. This is a "last resort" option.', 'Placeholders are HTML for links.', 'wp-to-diaspora' ),
-								'<a href="http://curl.haxx.se/ca/cacert.pem" download>', '</a>'
-							)
-							. '<br><p>' .
-							// See if we can do this automatically.
-							( ( ! array_diff( array( 'fopen', 'fwrite', 'fclose', 'file_get_contents', 'file_put_contents' ), get_defined_functions()['internal'] ) )
-								? sprintf(
-									esc_html_x( 'Your server should allow us to %sdo this%s for you :-)', 'Placeholders are HTML for links.', 'wp-to-diaspora' ),
-									'<a href="' . add_query_arg( 'temp_ssl_fix', '' ) . '" class="button">', '</a>'
-								)
-								: ''
-							)
-							. '</p>
-					</ul>
-					<p class="dashicons-before dashicons-info">' . esc_html__( 'NOTE: If you choose the temporary option, the copy procedure needs to be done every time the plugin is updated because all files get replaced!', 'wp-to-diaspora' ) . '</p>',
-			),
-			// Explain the meta box and the differences to the global defaults.
-			'meta-box' => array(
-				'title'   => esc_html__( 'Meta Box', 'wp-to-diaspora' ),
-				'content' => '<p><strong>' . esc_html__( 'The Meta Box is the new "WP to diaspora*" box you see when editing a post.', 'wp-to-diaspora' ) . '</strong></p>
-					<p>' . esc_html__( 'When creating or editing a post, you will notice a new meta box called "WP to diaspora*" which has some options. These options are almost the same as the options you can find in the "Defaults" tab on the settings page. These options are post-specific though, meaning they override the global defaults for the post itself. You will see that the default values are filled in automatically, allowing you to change individual ones as you please.', 'wp-to-diaspora' ) . '</p>
-					<p>' . esc_html__( 'There are a few important differences to the settings page:', 'wp-to-diaspora' ) . '</p>
-					<ul>
-						<li><strong>' . esc_html__( 'Already posted to diaspora*', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'If the post has already been posted to diaspora* a link to the diaspora* post will appear at the top.', 'wp-to-diaspora' ) . '
-						<li><strong>' . esc_html__( 'Custom tags', 'wp-to-diaspora' ) . '</strong>: ' .
-							esc_html__( 'A list of tags that gets added to this post. Note that they are seperate from the WordPress post tags!', 'wp-to-diaspora' ) . '
-					</ul>
-					<p class="dashicons-before dashicons-info">' . esc_html__( 'If you don\'t see the meta box, make sure the post type you\'re on has been added to the "Post types" list on the settings page. Also make sure it has been selected from the "Screen Options" at the top of the screen.', 'wp-to-diaspora' ) . '</p>',
-			),
-			// Show different ways to contribute to the plugin.
-			'contributing' => array(
-				'title'   => esc_html__( 'Contributing', 'wp-to-diaspora' ),
-				'content' => '<p><strong>' . esc_html__( 'So you feel like contributing to the WP to diaspora* plugin? Great!', 'wp-to-diaspora' ) . '</strong></p>
-					<p>' . esc_html__( 'There are many different ways that you can help out with this plugin:', 'wp-to-diaspora' ) . '</p>
-					<ul>
-						<li><a href="' . WP2D_EXT_GH_ISSUES_NEW . '" target="_blank">' . esc_html__( 'Report a bug', 'wp-to-diaspora' )           . '</a>
-						<li><a href="' . WP2D_EXT_GH_ISSUES_NEW . '" target="_blank">' . esc_html__( 'Suggest a new feature', 'wp-to-diaspora' )  . '</a>
-						<li><a href="' . WP2D_EXT_I18N          . '" target="_blank">' . esc_html__( 'Help with translations', 'wp-to-diaspora' ) . '</a>
-						<li><a href="' . WP2D_EXT_DONATE        . '" target="_blank">' . esc_html__( 'Make a donation', 'wp-to-diaspora' )        . '</a>
-					</ul>',
-			),
-		);
-	}
-
-	/**
-	 * Create / Get the instance of this class.
-	 *
-	 * @return WP2D_Contextual_Help Instance of this class.
-	 */
-	public static function get_instance() {
-		if ( ! isset( self::$_instance ) ) {
-			self::$_instance = new self();
-		}
-		return self::$_instance;
-	}
-
-	/**
-	 * Set up the contextual help menu.
-	 */
-	public static function setup() {
-		// Do we display the help tabs?
-		$post_type = get_current_screen()->post_type;
-		$enabled_post_types = WP2D_Options::get_instance()->get_option( 'enabled_post_types' );
-		if ( '' !== $post_type && ! in_array( $post_type, $enabled_post_types ) ) {
-			return;
-		}
-
-		// Get the unique instance.
-		$instance = self::get_instance();
-
-		// If the instance is already set up, just return it.
-		if ( self::$_is_set_up ) {
-			return $instance;
-		}
-
-		// If we don't have a post type, we're on the main settings page.
-		if ( '' === $post_type ) {
-			// Set the sidebar in the contextual help.
-			$instance->_set_sidebar();
-
-			// Add the main settings tabs and their content.
-			$instance->_add_settings_tabs();
-		} else {
-			// Add the post type specific tabs and their content.
-			$instance->_add_post_type_tabs();
-		}
-
-		// The instance has been set up.
-		self::$_is_set_up = true;
-
-		return $instance;
-	}
+	final private function __construct() { }
 
 	/**
 	 * Set the sidebar in the contextual help.
 	 */
 	private function _set_sidebar() {
-		get_current_screen()->set_help_sidebar( '<p><strong>' . esc_html__( 'WP to diaspora*', 'wp-to-diaspora' ) . '</strong></p>
+		get_current_screen()->set_help_sidebar(
+			'<p><strong>' . esc_html__( 'WP to diaspora*', 'wp-to-diaspora' ) . '</strong></p>
 			<ul>
 				<li><a href="' . WP2D_EXT_GH     . '" target="_blank">GitHub</a>
 				<li><a href="' . WP2D_EXT_WPORG  . '" target="_blank">WordPress.org</a>
@@ -234,35 +105,142 @@ class WP2D_Contextual_Help {
 	}
 
 	/**
-	 * Render the output of the selected tab.
-	 *
-	 * @param WP_Screen $screen Current screen.
-	 * @param array     $tab    Selected tab.
-	 */
-	public function render_tab( $screen, $tab ) {
-		echo $tab['callback'][0]->_settings_tabs[ $tab['id'] ]['content'];
-	}
-
-	/**
 	 * Add help tabs to the contextual help on the settings page.
 	 */
-	private function _add_settings_tabs() {
-		foreach ( $this->_settings_tabs as $id => $data ) {
-			get_current_screen()->add_help_tab( array(
-				'id'       => $id,
-				'title'    => $data['title'],
-				// Use the content only if you want to add something static on every help tab.
-				// Example: Another title inside the tab.
-				'content'  => '',
-				'callback' => array( $this, 'render_tab' ),
-			) );
-		}
+	private function _add_settings_help_tabs() {
+		$screen = get_current_screen();
+
+		// A short overview of the plugin.
+		$screen->add_help_tab( array(
+			'id'      => 'overview',
+			'title'   => esc_html__( 'Overview', 'wp-to-diaspora' ),
+			'content' => '<p><strong>' . esc_html__( 'With WP to diaspora*, sharing your WordPress posts to diaspora* is as easy as ever.', 'wp-to-diaspora' ) . '</strong></p>
+				<ol>
+					<li>' . esc_html__( 'Enter your diaspora* login details on the "Setup" tab.', 'wp-to-diaspora' ) . '
+					<li>' . esc_html__( 'Define the default posting behaviour on the "Defaults" tab.', 'wp-to-diaspora' ) . '
+					<li>' . esc_html__( 'Automatically share your WordPress post on diaspora* when publishing it on your website.', 'wp-to-diaspora' ) . '
+					<li>' . esc_html__( 'Check out your new post on diaspora*.', 'wp-to-diaspora' ) . '
+				</ol>'
+		) );
+
+		// How to set up the connection to diaspora*.
+		$screen->add_help_tab( array(
+			'id'      => 'setup',
+			'title'   => esc_html__( 'Setup', 'wp-to-diaspora' ),
+			'content' => '<p><strong>' . esc_html__( 'Enter your diaspora* login details to connect your account.', 'wp-to-diaspora' ) . '</strong></p>
+				<ul>
+					<li><strong>' . esc_html__( 'diaspora* Pod', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'This is the domain name of the pod you are on (e.g. joindiaspora.com)', 'wp-to-diaspora' ) . '<br>
+							<em>' . sprintf( esc_html__( 'Use the "%s" button to prepopulate the input field to help choose your pod.', 'wp-to-diaspora' ), esc_html__( 'Refresh pod list', 'wp-to-diaspora' ) ) . '</em>
+					<li><strong>' . esc_html__( 'Username', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'Your diaspora* username (without the pod domain).', 'wp-to-diaspora' ) . '
+					<li><strong>' . esc_html__( 'Password', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'Your diaspora* password.', 'wp-to-diaspora' ) . '
+				</ul>',
+		) );
+
+		// Explain the default options and what they do.
+		$screen->add_help_tab( array(
+			'id'      => 'defaults',
+			'title'   => esc_html__( 'Defaults', 'wp-to-diaspora' ),
+			'content' => '<p><strong>' . esc_html__( 'Define the default posting behaviour.', 'wp-to-diaspora' ) . '</strong></p>
+				<ul>
+					<li><strong>' . esc_html__( 'Post types', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'Choose the post types that are allowed to be shared to diaspora*.', 'wp-to-diaspora' ) . '
+					<li><strong>' . esc_html__( 'Post to diaspora*', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'Automatically share new posts to diaspora* when publishing them.', 'wp-to-diaspora' ) . '
+					<li><strong>' . esc_html__( 'Show "Posted at" link?', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'Add a link back to your original post, at the bottom of the diaspora* post.', 'wp-to-diaspora' ) . '
+					<li><strong>' . esc_html__( 'Display', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'Choose whether you would like to post the whole post or just the excerpt.', 'wp-to-diaspora' ) . '
+					<li><strong>' . esc_html__( 'Tags to post', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'You can add tags to your post to make it easier to find on diaspora*.' ) . '<br>
+							<ul>
+								<li><strong>' . esc_html__( 'Global tags', 'wp-to-diaspora' ) . '</strong>: ' . esc_html__( 'Tags that apply to all posts.', 'wp-to-diaspora' ) . '
+								<li><strong>' . esc_html__( 'Custom tags', 'wp-to-diaspora' ) . '</strong>: ' . esc_html__( 'Tags that apply to individual posts (can be set on each post).', 'wp-to-diaspora' ) . '
+								<li><strong>' . esc_html__( 'Post tags',   'wp-to-diaspora' ) . '</strong>: ' . esc_html__( 'Default WordPress Tags of individual posts.', 'wp-to-diaspora' ) . '
+							</ul>
+					<li><strong>' . esc_html__( 'Global tags', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'A list of tags that gets added to every post.', 'wp-to-diaspora' ) . '
+					<li><strong>' . esc_html__( 'Aspects', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'Decide which of your diaspora* aspects can see your posts.', 'wp-to-diaspora' ) . '<br>
+							<em>' . sprintf( esc_html__( 'Use the "%s" button to load your aspects from diaspora*.', 'wp-to-diaspora' ), esc_html__( 'Refresh Aspects', 'wp-to-diaspora' ) ) . '</em>
+					<li><strong>' . esc_html__( 'Services', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'Choose the services your new diaspora* post gets shared to.', 'wp-to-diaspora' ) . '<br>
+							<em>' . sprintf( esc_html__( 'Use the "%s" button to fetch the list of your connected services from diaspora*.', 'wp-to-diaspora' ), esc_html__( 'Refresh Services', 'wp-to-diaspora' ) ) . '</em>
+				</ul>',
+		) );
+
+		// Explain the importance of SSL connections to the pod and the CA certificate bundle.
+		$screen->add_help_tab( array(
+			'id'      => 'ssl',
+			'title'   => esc_html__( 'SSL', 'wp-to-diaspora' ),
+			'content' => '<p><strong>' . esc_html__( 'WP to diaspora* makes sure the connection to your pod is secure!', 'wp-to-diaspora' ) . '</strong></p>
+				<p>' . esc_html__( 'Most diaspora* pods are secured using SSL (Secure Sockets Layer), which makes your connection encrypted. For this connection to work, your server needs to know that those SSL certificates can be trusted.', 'wp-to-diaspora' ) . '</p>
+				<p>' . esc_html__( 'Therefore, if your server does not have an up to date CA certificate bundle, WP to diaspora* may not work for you.', 'wp-to-diaspora' ) . '</p>
+				<p>' . esc_html__( 'Lucky for you though, we have you covered if this is the case for you!', 'wp-to-diaspora' ) . '</p>
+				<ul>
+					<li><strong>' . esc_html__( 'Get in touch with your hosting provider', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'The best option is for you to get in touch with your hosting provider and ask them to update the bundle for you. They should know what you\'re talking about.', 'wp-to-diaspora' ) . '
+					<li><strong>' . esc_html__( 'Install the CA bundle yourself', 'wp-to-diaspora' ) . '</strong>: ' .
+						sprintf(
+							esc_html_x( 'If you maintain your own server, it\'s your job to keep the bundle up to date. You can find a short and simple way on how to do this %shere%s.', 'Placeholders are HTML for a link.', 'wp-to-diaspora' ),
+							'<a href="http://serverfault.com/a/394835" target="_blank">', '</a>'
+						) . '
+					<li><strong>' . esc_html__( 'Quick "temporary" fix', 'wp-to-diaspora' ) . '</strong>: ' .
+						sprintf(
+							esc_html_x( 'As a temporary solution, you can download the up to date %sCA certificate bundle%s (Right-click &#8594; Save As...) and place the cacert.pem file at the top level of the WP to diaspora* plugin folder. This is a "last resort" option.', 'Placeholders are HTML for links.', 'wp-to-diaspora' ),
+							'<a href="http://curl.haxx.se/ca/cacert.pem" download>', '</a>'
+						)
+						. '<br><p>' .
+						// See if we can do this automatically.
+						( ( ! array_diff( array( 'fopen', 'fwrite', 'fclose', 'file_get_contents', 'file_put_contents' ), get_defined_functions()['internal'] ) )
+							? sprintf(
+								esc_html_x( 'Your server should allow us to %sdo this%s for you :-)', 'Placeholders are HTML for links.', 'wp-to-diaspora' ),
+								'<a href="' . add_query_arg( 'temp_ssl_fix', '' ) . '" class="button">', '</a>'
+							)
+							: ''
+						)
+						. '</p>
+				</ul>
+				<p class="dashicons-before dashicons-info">' . esc_html__( 'NOTE: If you choose the temporary option, the copy procedure needs to be done every time the plugin is updated because all files get replaced!', 'wp-to-diaspora' ) . '</p>',
+		) );
+
+		// Explain the meta box and the differences to the global defaults.
+		$screen->add_help_tab( array(
+			'id' => 'meta-box',
+			'title'   => esc_html__( 'Meta Box', 'wp-to-diaspora' ),
+			'content' => '<p><strong>' . esc_html__( 'The Meta Box is the new "WP to diaspora*" box you see when editing a post.', 'wp-to-diaspora' ) . '</strong></p>
+				<p>' . esc_html__( 'When creating or editing a post, you will notice a new meta box called "WP to diaspora*" which has some options. These options are almost the same as the options you can find in the "Defaults" tab on the settings page. These options are post-specific though, meaning they override the global defaults for the post itself. You will see that the default values are filled in automatically, allowing you to change individual ones as you please.', 'wp-to-diaspora' ) . '</p>
+				<p>' . esc_html__( 'There are a few important differences to the settings page:', 'wp-to-diaspora' ) . '</p>
+				<ul>
+					<li><strong>' . esc_html__( 'Already posted to diaspora*', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'If the post has already been posted to diaspora* a link to the diaspora* post will appear at the top.', 'wp-to-diaspora' ) . '
+					<li><strong>' . esc_html__( 'Custom tags', 'wp-to-diaspora' ) . '</strong>: ' .
+						esc_html__( 'A list of tags that gets added to this post. Note that they are seperate from the WordPress post tags!', 'wp-to-diaspora' ) . '
+				</ul>
+				<p class="dashicons-before dashicons-info">' . esc_html__( 'If you don\'t see the meta box, make sure the post type you\'re on has been added to the "Post types" list on the settings page. Also make sure it has been selected from the "Screen Options" at the top of the screen.', 'wp-to-diaspora' ) . '</p>',
+		) );
+
+		// Show different ways to contribute to the plugin.
+		$screen->add_help_tab( array(
+			'id' => 'contributing',
+			'title'   => esc_html__( 'Contributing', 'wp-to-diaspora' ),
+			'content' => '<p><strong>' . esc_html__( 'So you feel like contributing to the WP to diaspora* plugin? Great!', 'wp-to-diaspora' ) . '</strong></p>
+				<p>' . esc_html__( 'There are many different ways that you can help out with this plugin:', 'wp-to-diaspora' ) . '</p>
+				<ul>
+					<li><a href="' . WP2D_EXT_GH_ISSUES_NEW . '" target="_blank">' . esc_html__( 'Report a bug', 'wp-to-diaspora' )           . '</a>
+					<li><a href="' . WP2D_EXT_GH_ISSUES_NEW . '" target="_blank">' . esc_html__( 'Suggest a new feature', 'wp-to-diaspora' )  . '</a>
+					<li><a href="' . WP2D_EXT_I18N          . '" target="_blank">' . esc_html__( 'Help with translations', 'wp-to-diaspora' ) . '</a>
+					<li><a href="' . WP2D_EXT_DONATE        . '" target="_blank">' . esc_html__( 'Make a donation', 'wp-to-diaspora' )        . '</a>
+				</ul>',
+		) );
 	}
 
 	/**
 	 * Add help tabs to the contextual help on the post pages.
 	 */
-	private function _add_post_type_tabs() {
+	private function _add_post_type_help_tabs() {
 		get_current_screen()->add_help_tab( array(
 			'id'       => 'wp-to-diaspora',
 			'title'    => esc_html__( 'WP to diaspora*', 'wp-to-diaspora' ),
@@ -272,5 +250,4 @@ class WP2D_Contextual_Help {
 			) . '</p>',
 		) );
 	}
-
 }

--- a/lib/class-contextual-help.php
+++ b/lib/class-contextual-help.php
@@ -22,13 +22,6 @@ class WP2D_Contextual_Help {
 	private static $_instance = null;
 
 	/**
-	 * The tab information for the settings page including the content.
-	 *
-	 * @var array
-	 */
-	private $_settings_tabs = array();
-
-	/**
 	 * Create / Get the instance of this class.
 	 *
 	 * @return WP2D_Contextual_Help Instance of this class.

--- a/lib/class-helpers.php
+++ b/lib/class-helpers.php
@@ -113,7 +113,7 @@ class WP2D_Helpers {
 	 * @return WP2D_API The API object.
 	 */
 	public static function api_quick_connect() {
-		$options   = WP2D_Options::get_instance();
+		$options   = WP2D_Options::instance();
 		$pod       = (string) $options->get_option( 'pod' );
 		$is_secure = true;
 		$username  = (string) $options->get_option( 'username' );

--- a/lib/class-options.php
+++ b/lib/class-options.php
@@ -15,13 +15,6 @@ defined( 'ABSPATH' ) || exit;
 class WP2D_Options {
 
 	/**
-	 * Have the options already been set up?
-	 *
-	 * @var boolean
-	 */
-	private static $_is_set_up = false;
-
-	/**
 	 * Only instance of this class.
 	 *
 	 * @var WP2D_Options
@@ -79,9 +72,10 @@ class WP2D_Options {
 	 *
 	 * @return WP2D_Options Instance of this class.
 	 */
-	public static function get_instance() {
+	public static function instance() {
 		if ( ! isset( self::$_instance ) ) {
 			self::$_instance = new self();
+			self::$_instance->_setup();
 		}
 		return self::$_instance;
 	}
@@ -89,36 +83,23 @@ class WP2D_Options {
 	/**
 	 * Set up the options menu.
 	 */
-	public static function setup() {
-		// Get the unique instance.
-		$instance = self::get_instance();
-
-		// If the instance is already set up, just return it.
-		if ( self::$_is_set_up ) {
-			return $instance;
-		}
+	private function _setup() {
 
 		// Populate options array.
-		$instance->get_option();
+		$this->get_option();
 
 		// Add options page.
-		$hook = add_options_page( 'WP to diaspora*', 'WP to diaspora*', 'manage_options', 'wp_to_diaspora', array( $instance, 'admin_options_page' ) );
+		$hook = add_options_page( 'WP to diaspora*', 'WP to diaspora*', 'manage_options', 'wp_to_diaspora', array( $this, 'admin_options_page' ) );
 
 		// Setup the contextual help menu after the options page has been loaded.
-		require_once WP2D_LIB_DIR . '/class-contextual-help.php';
-		add_action( 'load-' . $hook, array( 'WP2D_Contextual_Help', 'setup' ) );
+		add_action( 'load-' . $hook, array( 'WP2D_Contextual_Help', 'instance' ) );
 
 		// Setup the contextual help menu tab for post types. Checks are made there!
-		add_action( 'load-post.php', array( 'WP2D_Contextual_Help', 'setup' ) );
-		add_action( 'load-post-new.php', array( 'WP2D_Contextual_Help', 'setup' ) );
+		add_action( 'load-post.php', array( 'WP2D_Contextual_Help', 'instance' ) );
+		add_action( 'load-post-new.php', array( 'WP2D_Contextual_Help', 'instance' ) );
 
 		// Register all settings.
-		add_action( 'admin_init', array( $instance, 'register_settings' ) );
-
-		// The instance has been set up.
-		self::$_is_set_up = true;
-
-		return $instance;
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
 	}
 
 

--- a/lib/class-post.php
+++ b/lib/class-post.php
@@ -98,11 +98,23 @@ class WP2D_Post {
 	public $post_history = null;
 
 	/**
+	 * If the post actions have all been set up already.
+	 *
+	 * @var boolean
+	 * @since 1.5.0
+	 */
+	private static $_is_set_up = false;
+
+	/**
 	 * Setup all the necessary WP callbacks.
 	 *
 	 * @since 1.4.1
 	 */
 	public static function setup() {
+		if ( self::$_is_set_up ) {
+			return;
+		}
+
 		$instance = new WP2D_Post( null );
 
 		// Notices when a post has been shared or if it has failed.
@@ -115,6 +127,8 @@ class WP2D_Post {
 
 		// Add meta boxes.
 		add_action( 'add_meta_boxes', array( $instance, 'add_meta_boxes' ) );
+
+		self::$_is_set_up = true;
 	}
 
 	/**
@@ -139,7 +153,7 @@ class WP2D_Post {
 		if ( $this->post = get_post( $post ) ) {
 			$this->ID = $this->post->ID;
 
-			$options = WP2D_Options::get_instance();
+			$options = WP2D_Options::instance();
 
 			// Assign all meta values, expanding non-existent ones with the defaults..
 			$meta = wp_parse_args(
@@ -168,7 +182,7 @@ class WP2D_Post {
 	public function post( $post_id, $post ) {
 		$this->_assign_wp_post( $post );
 
-		$options = WP2D_Options::get_instance();
+		$options = WP2D_Options::instance();
 
 		// Is this post type enabled for posting?
 		if ( ! in_array( $post->post_type, $options->get_option( 'enabled_post_types' ) ) ) {
@@ -292,7 +306,7 @@ class WP2D_Post {
 	 * @return string Tags added to the post.
 	 */
 	private function _get_tags_to_add() {
-		$options = WP2D_Options::get_instance();
+		$options = WP2D_Options::instance();
 		$tags_to_post = $this->tags_to_post;
 		$custom_tags  = $this->custom_tags;
 		$tags_to_add  = '';
@@ -423,7 +437,7 @@ class WP2D_Post {
 	 * @since 1.4.1
 	 */
 	public function add_meta_boxes() {
-		$options = WP2D_Options::get_instance();
+		$options = WP2D_Options::instance();
 		foreach ( $options->get_option( 'enabled_post_types' ) as $post_type ) {
 			add_meta_box(
 				'wp_to_diaspora_meta_box',
@@ -450,7 +464,7 @@ class WP2D_Post {
 		wp_nonce_field( 'wp_to_diaspora_meta_box', 'wp_to_diaspora_meta_box_nonce' );
 
 		// Get the default values to use, but give priority to the meta data already set.
-		$options = WP2D_Options::get_instance();
+		$options = WP2D_Options::instance();
 
 		// Make sure we have some value for post meta fields.
 		$this->custom_tags = $this->custom_tags ?: array();
@@ -500,7 +514,7 @@ class WP2D_Post {
 
 		// Meta data to save.
 		$meta_to_save = $_POST['wp_to_diaspora_settings'];
-		$options = WP2D_Options::get_instance();
+		$options = WP2D_Options::instance();
 
 		// Checkboxes.
 		$options->validate_checkboxes( array( 'post_to_diaspora', 'fullentrylink' ), $meta_to_save );

--- a/readme.txt
+++ b/readme.txt
@@ -94,7 +94,9 @@ Quite straightforward, right?
 * SSL CA bundle check and download option
 * Move post related functionality to an own WP2D_Post class
 * Add a helper to facilitate API connections
-* Make code adhere to WordPress coding standards.
+* Make code adhere to WordPress coding standards
+* Make singleton classes initialisation and setup simpler
+* Simplify the contextual help class
 
 = 1.4.0 =
 * Split Settings page into tabs to give a better overview


### PR DESCRIPTION
Remove bulky initialisation.
Reorganise contextual help class to make it more readable.