### PR TITLE
Don't display the post title in the link title attribute, because it …

### DIFF
--- a/lib/class-post.php
+++ b/lib/class-post.php
@@ -259,9 +259,9 @@ class WP2D_Post {
 	 */
 	private function _get_title_link() {
 		return sprintf(
-			'<p><b><a href="%1$s" title="permalink to %2$s">%2$s</a></b></p>',
+			'<p><strong><a href="%1$s" title="%1$s">%2$s</a></strong></p>',
 			get_permalink( $this->ID ),
-			$this->post->post_title
+			esc_html( $this->post->post_title )
 		);
 	}
 
@@ -373,9 +373,9 @@ class WP2D_Post {
 		$link = '';
 		if ( $this->fullentrylink ) {
 			$link = sprintf( '%1$s [%2$s](%2$s "%3$s")',
-				__( 'Originally posted at:', 'wp-to-diaspora' ),
+				esc_html__( 'Originally posted at:', 'wp-to-diaspora' ),
 				get_permalink( $this->ID ),
-				$this->post->post_title
+				esc_html__( 'Permalink', 'wp-to-diaspora' )
 			);
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ Quite straightforward, right?
 
 = 1.5.2 =
 * Fixed scenario where old posts would get posted to diaspora* by default
+* Fixed problem with special characters in the post title
 
 = 1.5.1 =
 * Fixed bug affecting scheduled posts


### PR DESCRIPTION
…doesn't convert the special characters properly.
Fixes #80 