### PR TITLE
Image captions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,9 @@ Quite straightforward, right?
 
 == Changelog ==
 
+= 1.5.3 =
+* Gallery images and single images with captions get a pretty caption added to them
+
 = 1.5.2 =
 * Fixed scenario where old posts would get posted to diaspora* by default
 * Fixed problem with special characters in the post title


### PR DESCRIPTION
Add image captions to images in a pretty and extensible way.

The style of the caption can be changed via a filter like so:
```php
add_filter( 'wp2d_image_caption_wrapper', function() {
  return '<em>%s</em>';
} );
```

Fixes #52 