### PR TITLE
save_post hook priority fix

### DIFF
--- a/lib/class-post.php
+++ b/lib/class-post.php
@@ -124,7 +124,7 @@ class WP2D_Post {
 		add_action( 'admin_init', array( $instance, 'ignore_post_error' ) );
 
 		// Handle diaspora* posting when saving the post.
-		add_action( 'save_post', array( $instance, 'post' ), 20, 2 );
+		add_action( 'save_post', array( $instance, 'post' ), 11, 2 );
 		add_action( 'save_post', array( $instance, 'save_meta_box_data' ), 10 );
 
 		// Add meta boxes.


### PR DESCRIPTION
Modify the save_post hook priority to be compatible with WP to Twitter plugin.

The problem is, that WordPress has issues with plugins/themes removing and re-adding their own action hooks.
Read more here: https://core.trac.wordpress.org/ticket/17817

Fixes #125